### PR TITLE
#1: [Backend] Implementar CRUD completo de Usuarios #1

### DIFF
--- a/filehost/src/main/java/es/hgccarlos/filehost/config/SecurityConfig.java
+++ b/filehost/src/main/java/es/hgccarlos/filehost/config/SecurityConfig.java
@@ -53,13 +53,13 @@ public class SecurityConfig {
                         .roles("ADMIN")
                         .build();
             }
-            var u = userService.getByUsername(username);
-            return org.springframework.security.core.userdetails.User
-                    .withUsername(u.getUsername())
-                    .password(u.getPassword())
-                    .roles(u.getRole())
-                    .disabled(!u.isEnabled())
-                    .build();
+                var u = userService.getByUsername(username);
+                return org.springframework.security.core.userdetails.User
+                        .withUsername(u.getUsername())
+                        .password(u.getPassword())
+                        .roles(u.getRole())
+                        .disabled(!u.isEnabled())
+                        .build();
         };
     }
 
@@ -86,6 +86,8 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthFilter, BasicAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/api/users/create").permitAll()  // Registration public
+                        .requestMatchers("/api/users/**").authenticated()     // All other user endpoints require auth
                         .requestMatchers("/api/buckets/**").hasRole("ADMIN")
                         .requestMatchers("/api/files/**").authenticated()
                         .requestMatchers("/actuator/**").hasRole("ADMIN")

--- a/filehost/src/main/java/es/hgccarlos/filehost/controller/AuthenticationController.java
+++ b/filehost/src/main/java/es/hgccarlos/filehost/controller/AuthenticationController.java
@@ -1,6 +1,6 @@
 package es.hgccarlos.filehost.controller;
 
-import es.hgccarlos.filehost.dto.GeneralErrorResponse;
+// import es.hgccarlos.filehost.dto.GeneralErrorResponse;
 import es.hgccarlos.filehost.dto.JwtResponse;
 import es.hgccarlos.filehost.dto.LoginRequest;
 import es.hgccarlos.filehost.model.User;

--- a/filehost/src/main/java/es/hgccarlos/filehost/controller/UserController.java
+++ b/filehost/src/main/java/es/hgccarlos/filehost/controller/UserController.java
@@ -1,11 +1,20 @@
 package es.hgccarlos.filehost.controller;
 
+import es.hgccarlos.filehost.dto.UserDTO;
+import es.hgccarlos.filehost.dto.Response;
 import es.hgccarlos.filehost.model.User;
 import es.hgccarlos.filehost.service.UserService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/users")
@@ -14,14 +23,63 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/register")
-    public ResponseEntity<User> register(@RequestBody RegisterRequest req) {
-        User newUser = userService.createUser(req.getUsername(), req.getPassword(), req.getRole());
-        return ResponseEntity.ok(newUser);
+    // ---- Existing register endpoint ----
+    @PostMapping("/create")
+    public ResponseEntity<UserDTO> register(@RequestBody RegisterRequest req) {
+            User newUser = userService.createUser(req.getUsername(), req.getPassword(), req.getRole());
+            UserDTO userDTO = userService.toDTO(newUser);
+            return ResponseEntity.status(HttpStatus.CREATED).body(userDTO);
     }
 
+    // ---- GET /api/users - List all users (ADMIN only) ----
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<UserDTO>> getAllUsers() {
+        List<UserDTO> users = userService.getAllUsers();
+        return ResponseEntity.ok(users);
+    }
+
+    // ---- GET /api/users/{id} - Get user by ID (ADMIN or owner) ----
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or @userService.isUserOwner(#id, authentication.name)")
+    public ResponseEntity<UserDTO> getUserById(@PathVariable UUID id, Authentication authentication) {
+        UserDTO user = userService.getUserById(id);
+        return ResponseEntity.ok(user);
+    }
+
+    // ---- PUT /api/users/{id} - Update user (ADMIN or owner) ----
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or @userService.isUserOwner(#id, authentication.name)")
+    public ResponseEntity<UserDTO> updateUser(@PathVariable UUID id, 
+                                            @RequestBody UserDTO request,
+                                            Authentication authentication) {
+        // Non-admin users can't change role
+        boolean isAdmin = authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        if (!isAdmin && request.getRole() != null) {
+            throw new SecurityException("Only administrators can change user roles");
+        }
+        
+        UserDTO updatedUser = userService.updateUser(id, request);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    // ---- DELETE /api/users/{id} - Delete user (ADMIN only) ----
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Response> deleteUser(@PathVariable UUID id, Authentication authentication) {
+        
+        try {
+            userService.deleteUser(id);
+            return ResponseEntity.ok(new Response("success", "200", "User deleted successfully", null, null));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest()
+                    .body(new Response("error", "DELETE_FORBIDDEN", e.getMessage(), null, null));
+        }
+    }
+
+    // ---- Request DTOs ----
     @Data
-    static class RegisterRequest {
+    public static class RegisterRequest {
         private String username;
         private String password;
         private String role;

--- a/filehost/src/main/java/es/hgccarlos/filehost/dto/UserDTO.java
+++ b/filehost/src/main/java/es/hgccarlos/filehost/dto/UserDTO.java
@@ -1,0 +1,23 @@
+package es.hgccarlos.filehost.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDTO {
+    private UUID id;
+    private String username;
+    private String role;
+    private boolean enabled;
+    private LocalDateTime createdAt;
+
+}

--- a/filehost/src/main/java/es/hgccarlos/filehost/service/UserService.java
+++ b/filehost/src/main/java/es/hgccarlos/filehost/service/UserService.java
@@ -1,8 +1,22 @@
 package es.hgccarlos.filehost.service;
 
+import es.hgccarlos.filehost.dto.UserDTO;
 import es.hgccarlos.filehost.model.User;
+
+import java.util.List;
+import java.util.UUID;
 
 public interface UserService {
     User createUser(String username, String rawPassword, String role);
     User getByUsername(String username);
+    
+    // CRUD operations
+    List<UserDTO> getAllUsers();
+    UserDTO getUserById(UUID id);
+    UserDTO updateUser(UUID id, UserDTO request);
+    void deleteUser(UUID id);
+    
+    // Helper methods
+    UserDTO toDTO(User user);
+    boolean isUserOwner(UUID userId, String authenticatedUsername);
 }

--- a/filehost/src/main/java/es/hgccarlos/filehost/service/UserServiceImpl.java
+++ b/filehost/src/main/java/es/hgccarlos/filehost/service/UserServiceImpl.java
@@ -1,16 +1,24 @@
 package es.hgccarlos.filehost.service;
 
+import es.hgccarlos.filehost.dto.UserDTO;
 import es.hgccarlos.filehost.model.User;
 import es.hgccarlos.filehost.repository.UserRepository;
-import es.hgccarlos.filehost.service.UserService;
+
 import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserServiceImpl implements UserService {
 
     @Autowired
@@ -19,6 +27,7 @@ public class UserServiceImpl implements UserService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    // ---- Create User ----
     @Override
     public User createUser(String username, String rawPassword, String role) {
         if (userRepository.existsByUsername(username)) {
@@ -39,9 +48,101 @@ public class UserServiceImpl implements UserService {
 
     @PostConstruct
     public void createDefaultAdmin() {
-        if (!userRepository.existsByUsername("admin") && !userRepository.existsByUsername("user")) {
+        
+        if (!userRepository.existsByUsername("admin")) {
             createUser("admin", "admin123", "ADMIN");
+        }
+        if (!userRepository.existsByUsername("user")) {
             createUser("user", "user123", "USER");
+        }
+        
+    }
+
+    // ---- CRUD Operations ----
+
+    @Override
+    public List<UserDTO> getAllUsers() {
+        log.info("Fetching all users");
+        return userRepository.findAll()
+                .stream()
+                .map(this::toDTO)
+                .toList();
+    }
+
+    @Override
+    public UserDTO getUserById(UUID id) {
+        log.info("Fetching user by id: {}", id);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
+        return toDTO(user);
+    }
+
+    @Override
+    public UserDTO updateUser(UUID id, UserDTO request) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
+
+        // Update username if provided and different
+        if (request.getUsername() != null && !request.getUsername().equals(user.getUsername())) {
+            if (userRepository.existsByUsername(request.getUsername())) {
+                throw new IllegalArgumentException("Username already exists: " + request.getUsername());
+            }
+            user.setUsername(request.getUsername());
+        }
+
+        // Update role if provided
+        if (request.getRole() != null) {
+            user.setRole(request.getRole());
+        }
+
+        // Update enabled status if provided
+        user.setEnabled(request.isEnabled());
+
+        User updatedUser = userRepository.save(user);
+        return toDTO(updatedUser);
+    }
+
+    @Override
+    public void deleteUser(UUID id) {
+        log.info("Deleting user with id: {}", id);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + id));
+        
+        // Prevent deletion of the last admin user
+        if ("ADMIN".equals(user.getRole())) {
+            long adminCount = userRepository.findAll().stream()
+                    .filter(u -> "ADMIN".equals(u.getRole()))
+                    .count();
+            if (adminCount <= 1) {
+                throw new IllegalStateException("Cannot delete the last admin user");
+            }
+        }
+
+        userRepository.delete(user);
+        log.info("User deleted successfully: {}", user.getUsername());
+    }
+
+    // ---- Helper Methods ----
+
+    @Override
+    public UserDTO toDTO(User user) {
+        return new UserDTO(
+                user.getId(),
+                user.getUsername(),
+                user.getRole(),
+                user.isEnabled(),
+                user.getCreatedAt()
+        );
+    }
+
+    @Override
+    public boolean isUserOwner(UUID userId, String authenticatedUsername) {
+        try {
+            User user = userRepository.findById(userId).orElse(null);
+            return user != null && user.getUsername().equals(authenticatedUsername);
+        } catch (Exception e) {
+            log.warn("Error checking user ownership: {}", e.getMessage());
+            return false;
         }
     }
 }

--- a/filehost/src/test/java/es/hgccarlos/filehost/controller/UserControllerTest.java
+++ b/filehost/src/test/java/es/hgccarlos/filehost/controller/UserControllerTest.java
@@ -1,0 +1,293 @@
+package es.hgccarlos.filehost.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.hgccarlos.filehost.config.ApiKeyFilter;
+import es.hgccarlos.filehost.config.IpRateLimitFilter;
+import es.hgccarlos.filehost.config.JwtAuthFilter;
+
+import es.hgccarlos.filehost.dto.UserDTO;
+import es.hgccarlos.filehost.model.User;
+import es.hgccarlos.filehost.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = UserController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {
+                        IpRateLimitFilter.class,
+                        JwtAuthFilter.class,
+                        ApiKeyFilter.class
+                }
+        )
+)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // Test data
+    private final UUID userId1 = UUID.randomUUID();
+    private final UUID userId2 = UUID.randomUUID();
+    private final LocalDateTime now = LocalDateTime.now();
+
+    @Test
+    @DisplayName("POST /api/users/create - Should register new user successfully")
+    void testRegisterUser_Success() throws Exception {
+        // Arrange
+        UserController.RegisterRequest request = new UserController.RegisterRequest();
+        request.setUsername("testuser");
+        request.setPassword("password123");
+        request.setRole("USER");
+
+        User mockUser = User.builder()
+                .id(userId1)
+                .username("testuser")
+                .role("USER")
+                .enabled(true)
+                .createdAt(now)
+                .build();
+
+        UserDTO expectedDTO = new UserDTO(userId1, "testuser", "USER", true, now);
+
+        when(userService.createUser("testuser", "password123", "USER")).thenReturn(mockUser);
+        when(userService.toDTO(mockUser)).thenReturn(expectedDTO);
+
+        // Act & Assert
+        mockMvc.perform(post("/api/users/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(userId1.toString())))
+                .andExpect(jsonPath("$.username", is("testuser")))
+                .andExpect(jsonPath("$.role", is("USER")))
+                .andExpect(jsonPath("$.enabled", is(true)));
+    }
+
+    @Test
+    @DisplayName("POST /api/users/create - Should fail when username already exists")
+    void testRegisterUser_DuplicateUsername_ShouldFail() throws Exception {
+        UserController.RegisterRequest request = new UserController.RegisterRequest();
+        request.setUsername("duplicate");
+        request.setPassword("pass");
+        request.setRole("USER");
+
+        when(userService.createUser("duplicate", "pass", "USER"))
+                .thenThrow(new IllegalArgumentException("Username already exists"));
+
+        mockMvc.perform(post("/api/users/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is("error")))
+                .andExpect(jsonPath("$.code", is("RUNTIME_EXCEPTION")));
+    }
+
+    @Test
+    @DisplayName("GET /api/users - Should return all users for ADMIN")
+    @WithMockUser(roles = "ADMIN")
+    void testGetAllUsers_AsAdmin() throws Exception {
+        List<UserDTO> mockUsers = Arrays.asList(
+                new UserDTO(userId1, "admin", "ADMIN", true, now),
+                new UserDTO(userId2, "user", "USER", true, now)
+        );
+
+        when(userService.getAllUsers()).thenReturn(mockUsers);
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].username", is("admin")))
+                .andExpect(jsonPath("$[0].role", is("ADMIN")))
+                .andExpect(jsonPath("$[1].username", is("user")))
+                .andExpect(jsonPath("$[1].role", is("USER")));
+    }
+
+    @Test
+    @DisplayName("GET /api/users - Should deny access for non-ADMIN")
+    @WithMockUser(roles = "USER")
+    void testGetAllUsers_AsUser_ShouldFail() throws Exception {
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{id} - Should return user by ID for ADMIN")
+    @WithMockUser(roles = "ADMIN")
+    void testGetUserById_AsAdmin() throws Exception {
+        UserDTO mockUser = new UserDTO(userId1, "testuser", "USER", true, now);
+        when(userService.getUserById(userId1)).thenReturn(mockUser);
+
+        mockMvc.perform(get("/api/users/{id}", userId1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(userId1.toString())))
+                .andExpect(jsonPath("$.username", is("testuser")))
+                .andExpect(jsonPath("$.role", is("USER")));
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{id} - Should return own user data for user owner")
+    @WithMockUser(username = "testuser", roles = "USER")
+    void testGetUserById_AsOwner() throws Exception {
+        UserDTO mockUser = new UserDTO(userId1, "testuser", "USER", true, now);
+        when(userService.isUserOwner(userId1, "testuser")).thenReturn(true);
+        when(userService.getUserById(userId1)).thenReturn(mockUser);
+
+        mockMvc.perform(get("/api/users/{id}", userId1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is("testuser")));
+    }
+
+    @Test
+    @DisplayName("GET /api/users/{id} - Should deny access when not owner and not ADMIN")
+    @WithMockUser(username = "otheruser", roles = "USER")
+    void testGetUserById_NotOwner_ShouldFail() throws Exception {
+        // Arrange – ensure ownership check fails
+        when(userService.isUserOwner(userId1, "otheruser")).thenReturn(false);
+        // Service shouldn't be called further, but safe to stub
+        when(userService.getUserById(any())).thenReturn(null);
+
+        mockMvc.perform(get("/api/users/{id}", userId1))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/{id} - Should update user successfully as ADMIN")
+    @WithMockUser(roles = "ADMIN")
+    void testUpdateUser_AsAdmin() throws Exception {
+        UserDTO request = new UserDTO();
+        request.setUsername("newusername");
+        request.setRole("ADMIN");
+        request.setEnabled(false);
+
+        UserDTO updatedUser = new UserDTO(userId1, "newusername", "ADMIN", false, now);
+        when(userService.updateUser(eq(userId1), any())).thenReturn(updatedUser);
+
+        mockMvc.perform(put("/api/users/{id}", userId1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is("newusername")))
+                .andExpect(jsonPath("$.role", is("ADMIN")))
+                .andExpect(jsonPath("$.enabled", is(false)));
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/{id} - Should update own user data but not role")
+    @WithMockUser(username = "testuser", roles = "USER")
+    void testUpdateUser_AsOwner_CannotChangeRole() throws Exception {
+        UserDTO request = new UserDTO();
+        request.setUsername("newusername");
+        request.setRole("ADMIN"); // This should cause security exception
+
+        when(userService.isUserOwner(userId1, "testuser")).thenReturn(true);
+
+        mockMvc.perform(put("/api/users/{id}", userId1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError()); // SecurityException should cause 500
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/{id} - Should deny update when not owner and not ADMIN")
+    @WithMockUser(username = "otheruser", roles = "USER")
+    void testUpdateUser_NotOwner_ShouldFail() throws Exception {
+        UserDTO request = new UserDTO();
+        request.setUsername("whatever");
+
+        when(userService.isUserOwner(userId1, "otheruser")).thenReturn(false);
+
+        mockMvc.perform(put("/api/users/{id}", userId1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/{id} - Should update own user data (without role) successfully")
+    @WithMockUser(username = "testuser", roles = "USER")
+    void testUpdateUser_AsOwner_Success() throws Exception {
+        UserDTO request = new UserDTO();
+        request.setUsername("mynewname");
+        request.setEnabled(false);
+
+        UserDTO updated = new UserDTO(userId1, "mynewname", "USER", false, now);
+
+        when(userService.isUserOwner(userId1, "testuser")).thenReturn(true);
+        when(userService.updateUser(eq(userId1), any())).thenReturn(updated);
+
+        mockMvc.perform(put("/api/users/{id}", userId1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is("mynewname")))
+                .andExpect(jsonPath("$.role", is("USER")))
+                .andExpect(jsonPath("$.enabled", is(false)));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/users/{id} - Should delete user successfully as ADMIN")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteUser_AsAdmin_Success() throws Exception {
+
+        mockMvc.perform(delete("/api/users/{id}", userId1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("success")))
+                .andExpect(jsonPath("$.message", is("User deleted successfully")));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/users/{id} - Should fail when trying to delete last admin")
+    @WithMockUser(roles = "ADMIN")
+    void testDeleteUser_LastAdmin_ShouldFail() throws Exception {
+
+        doThrow(new IllegalStateException("Cannot delete the last admin user"))
+                .when(userService).deleteUser(userId1);
+
+        mockMvc.perform(delete("/api/users/{id}", userId1))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status", is("error")))
+                .andExpect(jsonPath("$.code", is("DELETE_FORBIDDEN")));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/users/{id} - Should deny access for non-ADMIN")
+    @WithMockUser(roles = "USER")
+    void testDeleteUser_AsUser_ShouldFail() throws Exception {
+
+        mockMvc.perform(delete("/api/users/{id}", userId1))
+                .andExpect(status().isForbidden());
+    }
+
+    
+    
+}


### PR DESCRIPTION
# [Backend] Implementar CRUD completo de Usuarios

Fixes #1

## ¿Qué hace este PR?

Implementa las operaciones CRUD completas para la gestión de usuarios según el issue original:
- **GET /api/users** - Listar usuarios (solo ADMIN)
- **GET /api/users/{id}** - Obtener usuario por ID (ADMIN o propietario)
- **PUT /api/users/{id}** - Actualizar usuario (ADMIN o propietario)
- **DELETE /api/users/{id}** - Eliminar usuario (solo ADMIN)

## Cambios adicionales realizados

- Comenté un import en `AuthenticationController.java` que causaba errores
- Protegí el cambio de roles: solo usuarios ADMIN pueden modificar roles de otros usuarios
- Corregí la función `createDefaultAdmin` - la lógica condicional estaba causando problemas
- Los tests me dieron errores de contexto de Spring, por lo que aunque hice la base de la implementación basado en otros tests del proyecto, no pude testear la suite completa.

## Cómo probar

Usar Postman con estos endpoints:

```
GET {{base_url}}/api/users
GET {{base_url}}/api/users/{{user_id}}
POST {{base_url}}/api/users/create
PUT {{base_url}}/api/users/{{user_id}}
DELETE {{base_url}}/api/users/{{user_id}}
```

Payload ejemplo para crear usuario:
```json
{
  "username": "jdoe",
  "password": "user123", 
  "role": "USER"
}

```

Payload ejemplo para actualizar usuario:
```json
{
  "username": "jane_doe"
}

```

*Nota: En caso de solucionar el problema del contexto de los tests, se puede usar la test de suites para testear los endpoints también*